### PR TITLE
Add Cutscene Frame Generation & Cutscene Framerate Unlock patches

### DIFF
--- a/GreatCircleFix.ini
+++ b/GreatCircleFix.ini
@@ -17,3 +17,16 @@ Enabled = true
 [Fix Culling]
 ; Set to true to fix culling issues at wider aspect ratios.
 Enabled = true
+
+;;;;;;;;;; Framerate ;;;;;;;;;;
+
+[Cutscene Frame Generation]
+; Set to true to allow frame generation during cutscenes, usually allowing 60FPS -> 120FPS
+; Can also be used with framerate unlock below, though framerate unlock isn't required for frame generation to work
+Enabled = true
+
+[Cutscene Framerate Unlock]
+; Set to true to remove 60FPS cap from cutscenes
+; Hasn't been tested with every cutscene in the game yet, possible it could have timing issues with certain scenes
+; Using frame generation above by itself should be more safe
+Enabled = false


### PR DESCRIPTION
Tested with latest MS store version

Made framegen enabled by default while framerate unlock is disabled, seemed the best config to me, but feel free to change it if you like.

Minor fix in ini code which might help unicode paths, also added an error to log file if INI failed to read since I didn't see the console window at first :P