### PR TITLE
Cutscene Framerate Unlock: add fix for update 2

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -383,7 +383,16 @@ void Framerate()
             spdlog::info("Cutscene Framerate Unlock: Enabled framerate unlock.");
         }
         else {
-            spdlog::error("Cutscene Framerate Unlock: Pattern scan failed.");
+            // Update 2 added extra checks around where we patch, check for those separately
+            CutsceneFramerateScanResult = Memory::PatternScan(exeModule, "48 8B 41 28 48 39 98 08 03 00 00 75 1C");
+            if (CutsceneFramerateScanResult) {
+                spdlog::info("Cutscene Framerate Unlock (Upd2): Address is {:s}+{:x}", sExeName.c_str(), CutsceneFramerateScanResult - (std::uint8_t*)exeModule);
+                Memory::PatchBytes(CutsceneFramerateScanResult + 0xB, "\x90\x90", 2);
+                spdlog::info("Cutscene Framerate Unlock (Upd2): Enabled framerate unlock.");
+            }
+            else {
+                spdlog::error("Cutscene Framerate Unlock: Pattern scan failed.");
+            }
         }
     }
 }


### PR DESCRIPTION
Adds update 2 support for framerate unlock, original check is also there in case someone is playing original ver

afaik update 2 added some extra stuff that would also limit to 60FPS, this doesn't affect those atm, not really sure what triggers them yet (cutscenes should get unlocked fine though)